### PR TITLE
[perf] Reduce blending in AlbumDelegate

### DIFF
--- a/qml/components/AlbumDelegate.qml
+++ b/qml/components/AlbumDelegate.qml
@@ -6,6 +6,11 @@ ListItem {
         width: albumGridView.cellWidth
         contentHeight: albumGridView.cellHeight
 
+        layer.enabled: true
+        layer.effect: ShaderEffect {
+            blending: highlighted
+        }
+
         Rectangle {
             anchors.fill: parent
             anchors.margins: Theme.paddingSmall


### PR DESCRIPTION
Some hw has limited GPU capability for overdraw. This change enables
caching AlbumDelegates to FBOs which are then drawn without blending
in the usual case.
