### PR TITLE
Escape infinite loop when reading invalid data

### DIFF
--- a/src/localdb/lastfmartistprovider.cpp
+++ b/src/localdb/lastfmartistprovider.cpp
@@ -95,6 +95,9 @@ void LastFMArtistProvider::parseArtist(QXmlStreamReader &xmlReader) {
     bool foundPreferredArtistArt = false;
 
     while ( !(xmlReader.tokenType() == QXmlStreamReader::EndElement && xmlReader.name() == "artist") ) {
+        if (xmlReader.tokenType() == QXmlStreamReader::Invalid) {
+            return;
+        }
         if ( xmlReader.tokenType() == QXmlStreamReader::StartElement &&
              xmlReader.name() == "image" && !foundPreferredArtistArt ) {
 
@@ -147,6 +150,9 @@ void LastFMArtistProvider::parseWikiInformation(QXmlStreamReader &xmlReader) {
         if ( xmlReader.tokenType() == QXmlStreamReader::StartElement &&
              xmlReader.name() == "content") {
             while ( !(xmlReader.tokenType() == QXmlStreamReader::EndElement && xmlReader.name() == "content") )  {
+                if (xmlReader.tokenType() == QXmlStreamReader::Invalid) {
+                    return;
+                }
                 if ( xmlReader.tokenType() == QXmlStreamReader::Characters ) {
                     qDebug() << "Reached content block";
                     mArtistInfo.append(xmlReader.text().toString());


### PR DESCRIPTION
It looks like last.fm can provide malformed XML files, that makes SMPC
loop forever attempting to read data.

As an example, the artist Randy Twigg currently triggers the problem
when SMPC tries to parse the contents of this page:
http://ws.audioscrobbler.com/2.0/?method=artist.getinfo&api_key=1c728df8f626849518971eaae29e01a1&artist=Randy%20Twigg

This patch attempts to detect such error condition and stop processing.
