### PR TITLE
Allow different punctuation spacing rules in translations.

### DIFF
--- a/harbour-smpc_de.ts
+++ b/harbour-smpc_de.ts
@@ -1013,9 +1013,9 @@
     </message>
     <message>
         <location filename="qml/pages/MainPage.qml" line="26"/>
-        <source>connected to</source>
-        <oldsource>connected</oldsource>
-        <translation>verbunden mit</translation>
+        <source>connected to: %1</source>
+        <oldsource>connected to</oldsource>
+        <translation>verbunden mit: %1</translation>
     </message>
     <message>
         <location filename="qml/pages/MainPage.qml" line="26"/>

--- a/harbour-smpc_fr.ts
+++ b/harbour-smpc_fr.ts
@@ -830,8 +830,9 @@
     <name>MainPage</name>
     <message>
         <location filename="qml/pages/MainPage.qml" line="26"/>
-        <source>connected to</source>
-        <translation>Connecté à</translation>
+        <source>connected to: %1</source>
+        <oldsource>connected to</oldsource>
+        <translation>Connecté à : %1</translation>
     </message>
     <message>
         <location filename="qml/pages/MainPage.qml" line="26"/>

--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -23,7 +23,7 @@ Page {
         }
         horizontalAlignment: Text.AlignHCenter
         color: Theme.highlightColor
-        text: connected ? qsTr("connected to") + ": " + profilename : qsTr(
+        text: connected ? qsTr("connected to: %1").arg(profilename) : qsTr(
                               "disconnected")
     }
     SilicaFlickable {


### PR DESCRIPTION
I did not regenerate the `.qm` files because this would conflict with #5.  Maybe these `.qm` file could be automatically updated by the build system and removed from the version control system ?
