### PR TITLE
Hide PullDownMenu.

### DIFF
--- a/qml/pages/database/AlbumListPage.qml
+++ b/qml/pages/database/AlbumListPage.qml
@@ -46,7 +46,7 @@ Page {
                     height: Theme.itemSizeMedium
                 }
                 PullDownMenu {
-                    enabled: artistname !== ""
+                    visible: artistname !== ""
                     MenuItem {
                         text: qsTr("add albums")
                         onClicked: {


### PR DESCRIPTION
When browsing all artists, the PullDownMenu is disabled but visible,
causing confusion.  Hide it instead, so that the user is not confused.
